### PR TITLE
Changed "endl" with "\n" in line 51

### DIFF
--- a/single-number.cpp
+++ b/single-number.cpp
@@ -48,7 +48,7 @@ int main() {
         int ret = Solution().singleNumber(nums);
 
         string out = to_string(ret);
-        cout << out << endl;
+        cout << out << "\n";
     }
     return 0;
 }


### PR DESCRIPTION
This should run faster because std::endl always flushes the stream. In turn, \n simply puts a new line character to the stream, and in most cases this is exactly what you need. And std::flush, if necessary, can be called afterwards, once, explicitly.